### PR TITLE
feat: 공통 예외 처리를 위한 공통 응답 생성

### DIFF
--- a/src/main/java/com/neodo/neodo_backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/neodo/neodo_backend/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,20 @@
+package com.neodo.neodo_backend.common.exception;
+
+import com.neodo.neodo_backend.common.response.CommonResponse;
+import com.neodo.neodo_backend.exception.CustomException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<CommonResponse<?>> handleCustomException(CustomException e) {
+        return ResponseEntity
+                .status(e.getResponse().getHttpStatus())
+                .body(CommonResponse.builder()
+                        .response(e.getResponse())
+                        .build());
+    }
+}

--- a/src/main/java/com/neodo/neodo_backend/common/response/CommonResponse.java
+++ b/src/main/java/com/neodo/neodo_backend/common/response/CommonResponse.java
@@ -1,0 +1,21 @@
+package com.neodo.neodo_backend.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CommonResponse<T> {
+
+    private final HttpStatus statusCode;
+    private final String message;
+    private final T data;
+
+    @Builder
+    public CommonResponse(Response response, T data) {
+        this.statusCode = response.getHttpStatus();
+        this.message = response.getMessage();
+        this.data = data;
+    }
+
+}

--- a/src/main/java/com/neodo/neodo_backend/common/response/Response.java
+++ b/src/main/java/com/neodo/neodo_backend/common/response/Response.java
@@ -1,0 +1,8 @@
+package com.neodo.neodo_backend.common.response;
+
+import org.springframework.http.HttpStatus;
+
+public interface Response {
+    HttpStatus getHttpStatus();
+    String getMessage();
+}

--- a/src/main/java/com/neodo/neodo_backend/common/response/responseEnum/ErrorResponseEnum.java
+++ b/src/main/java/com/neodo/neodo_backend/common/response/responseEnum/ErrorResponseEnum.java
@@ -1,0 +1,24 @@
+package com.neodo.neodo_backend.common.response.responseEnum;
+
+import com.neodo.neodo_backend.common.response.Response;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorResponseEnum implements Response {
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "Unauthorized User"),
+
+    // auth
+    AUTHENTICATION_IO_EXCEPTION(HttpStatus.BAD_REQUEST, "Client Send Bad Request"),
+    TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "Refresh Token Cannot Be Found"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "Expired JWT Token. Login Again Is Needed."),
+    UNEXPECTED_AUTH_ERROR(HttpStatus.UNAUTHORIZED, "Unexpected Authentication Error"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid Token"),
+    UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "Unsupported Token"),;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}
+

--- a/src/main/java/com/neodo/neodo_backend/common/response/responseEnum/SuccessResponseEnum.java
+++ b/src/main/java/com/neodo/neodo_backend/common/response/responseEnum/SuccessResponseEnum.java
@@ -1,0 +1,16 @@
+package com.neodo.neodo_backend.common.response.responseEnum;
+
+import com.neodo.neodo_backend.common.response.Response;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessResponseEnum implements Response {
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+}

--- a/src/main/java/com/neodo/neodo_backend/exception/CustomException.java
+++ b/src/main/java/com/neodo/neodo_backend/exception/CustomException.java
@@ -1,0 +1,11 @@
+package com.neodo.neodo_backend.exception;
+
+import com.neodo.neodo_backend.common.response.Response;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public abstract class CustomException extends RuntimeException{
+    private final Response response;
+}

--- a/src/main/java/com/neodo/neodo_backend/exception/impl/AuthException.java
+++ b/src/main/java/com/neodo/neodo_backend/exception/impl/AuthException.java
@@ -1,0 +1,11 @@
+package com.neodo.neodo_backend.exception.impl;
+
+import com.neodo.neodo_backend.common.response.Response;
+import com.neodo.neodo_backend.exception.CustomException;
+
+public class AuthException extends CustomException {
+
+    public AuthException(Response response) {
+        super(response);
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 공통 예외 처리를 위한 GlobalExceptionHandler 생성,
- 예외 처리 세분화를 위한 상위 예외와 세분화된 예외 생성
- 응답부 통일을 위한 응답 enum 생성

  <br/>

## 이미지 첨부
- 예) CommonResponse를 통해 응답부를 통일하면 다음과 같은 Response를 받을 수 있습니다. 
<img width="607" alt="스크린샷 2025-02-06 오후 6 29 26" src="https://github.com/user-attachments/assets/f736a38f-4773-4ca8-b770-9b66206f450f" />

- 예) 예외를 던지면 공통 예외 처리를 통해 다음과 같이 예외를 잡을 수 있습니다.
<img width="621" alt="스크린샷 2025-02-06 오후 6 34 11" src="https://github.com/user-attachments/assets/8100c234-ac57-42bc-aa1a-c3e2170126e3" />

<br/>

## 🔧 앞으로의 과제

- 추후 모든 응답부를 commonResponse를 이용하여 변경하여야 합니다.
- 추후 모든 예외를 CustomException을 통해서 던질 수 있도록 변경하여야 합니다.

  <br/>

## ➕ 이슈 링크

- [neodo_backend #10 ]

<br/>
