### PR TITLE
refactor: 스피치 코칭 피드백 가져오기

### DIFF
--- a/src/main/java/com/neodo/neodo_backend/external/flask/utils/FlaskRequestUtils.java
+++ b/src/main/java/com/neodo/neodo_backend/external/flask/utils/FlaskRequestUtils.java
@@ -55,7 +55,7 @@ public class FlaskRequestUtils {
         try {
             ResponseEntity<SpeechCoachingFeedbackResponse> responseEntity = restTemplate.exchange(
                     UriComponentsBuilder.fromHttpUrl(flaskServerUrl)
-                            .path("/coach")
+                            .path("coach")
                             .toUriString(),
                     HttpMethod.POST,
                     requestEntity,

--- a/src/main/java/com/neodo/neodo_backend/external/flask/utils/FlaskRequestUtils.java
+++ b/src/main/java/com/neodo/neodo_backend/external/flask/utils/FlaskRequestUtils.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import static com.neodo.neodo_backend.common.response.responseEnum.ErrorResponseEnum.EXTERNAL_SERVICE_ERROR;
 import static com.neodo.neodo_backend.common.response.responseEnum.ErrorResponseEnum.RESPONSE_NOT_VALID;
@@ -53,7 +54,9 @@ public class FlaskRequestUtils {
 
         try {
             ResponseEntity<SpeechCoachingFeedbackResponse> responseEntity = restTemplate.exchange(
-                    flaskServerUrl + "coach",
+                    UriComponentsBuilder.fromHttpUrl(flaskServerUrl)
+                            .path("/coach")
+                            .toUriString(),
                     HttpMethod.POST,
                     requestEntity,
                     SpeechCoachingFeedbackResponse.class

--- a/src/main/java/com/neodo/neodo_backend/speechCoachingFeedback/dto/request/SpeechCoachingFeedbackRequest.java
+++ b/src/main/java/com/neodo/neodo_backend/speechCoachingFeedback/dto/request/SpeechCoachingFeedbackRequest.java
@@ -1,7 +1,9 @@
 package com.neodo.neodo_backend.speechCoachingFeedback.dto.request;
 
 import lombok.Builder;
+import lombok.Getter;
 
+@Getter
 public class SpeechCoachingFeedbackRequest {
     private String record;
 


### PR DESCRIPTION
## 🔎 작업 내용

- 스피치 코칭 피드백을 플라스크 서버에서 가져올 수 있도록 기존 오류 코드를 수정했습니다.

  <br/>

## 이미지 첨부
<img width="1207" alt="스크린샷 2025-02-27 오후 7 40 21" src="https://github.com/user-attachments/assets/894b5fe8-3e56-4e3e-a18a-bc71101a2c56" />

<br/>

## 🔧 앞으로의 과제

- modifiedStt 반환

  <br/>

## ➕ 이슈 링크

- [neodo_backend #33 ]

<br/>
