### PR TITLE
refactor: 스피치 총평

### DIFF
--- a/src/main/java/com/neodo/neodo_backend/speechBoardFeedback/controller/SpeechBoardFeedbackController.java
+++ b/src/main/java/com/neodo/neodo_backend/speechBoardFeedback/controller/SpeechBoardFeedbackController.java
@@ -18,7 +18,7 @@ public class SpeechBoardFeedbackController {
 
     private final SpeechBoardFeedbackService speechBoardFeedbackService;
 
-    @PostMapping("/{speech-board-id}/feedback")
+    @GetMapping ("/{speech-board-id}/feedback")
     public ResponseEntity<CommonResponse<SpeechBoardFeedbackResponse>> getFeedback(@PathVariable("speech-board-id") Long speechBoardId) {
         SpeechBoardFeedbackResponse speechBoardFeedbackResponse = speechBoardFeedbackService.getFeedback(speechBoardId);
         return ResponseEntity.ok()

--- a/src/main/java/com/neodo/neodo_backend/speechBoardFeedback/dto/response/SpeechBoardFeedbackResponse.java
+++ b/src/main/java/com/neodo/neodo_backend/speechBoardFeedback/dto/response/SpeechBoardFeedbackResponse.java
@@ -1,11 +1,17 @@
 package com.neodo.neodo_backend.speechBoardFeedback.dto.response;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class SpeechBoardFeedbackResponse {
     private String originalStt;
     private int score;

--- a/src/main/java/com/neodo/neodo_backend/speechBoardFeedback/service/SpeechBoardFeedbackServiceImpl.java
+++ b/src/main/java/com/neodo/neodo_backend/speechBoardFeedback/service/SpeechBoardFeedbackServiceImpl.java
@@ -18,6 +18,9 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 
 @Service
 @RequiredArgsConstructor
@@ -31,10 +34,33 @@ public class SpeechBoardFeedbackServiceImpl implements SpeechBoardFeedbackServic
 
     @Override
     public SpeechBoardFeedbackResponse getFeedback(Long speechBoardId) {
-        SpeechBoardEntity speechBoardEntity = speechBoardRepository.findById(speechBoardId)
-                .orElseThrow(() -> new ResourceException(ErrorResponseEnum.RESOURCE_NOT_FOUND));
+        SpeechBoardEntity speechBoardEntity = getSpeechBoardEntity(speechBoardId);
 
-        SpeechBoardFeedbackRequest speechBoardFeedbackRequest = SpeechBoardFeedbackRequest.builder()
+        return speechBoardFeedbackRepository.findBySpeechBoardEntity_Id(speechBoardEntity.getId())
+                .map(feedbackEntity -> buildFeedbackResponseFromEntity(feedbackEntity, speechBoardEntity))
+                .orElseGet(() -> createAndSaveFeedback(speechBoardEntity));
+    }
+
+    private SpeechBoardEntity getSpeechBoardEntity(Long speechBoardId) {
+        return speechBoardRepository.findById(speechBoardId)
+                .orElseThrow(() -> new ResourceException(ErrorResponseEnum.RESOURCE_NOT_FOUND));
+    }
+
+    private SpeechBoardFeedbackResponse buildFeedbackResponseFromEntity(SpeechBoardFeedbackEntity feedbackEntity, SpeechBoardEntity speechBoardEntity) {
+        List<String> topics = topicRepository.findBySpeechBoardEntity(speechBoardEntity).stream()
+                .map(TopicEntity::getTopic)
+                .collect(Collectors.toList());
+
+        return SpeechBoardFeedbackResponse.builder()
+                .originalStt(feedbackEntity.getOriginalStt())
+                .conclusion(feedbackEntity.getConclusion())
+                .score(feedbackEntity.getScore())
+                .topics(topics)
+                .build();
+    }
+
+    private SpeechBoardFeedbackResponse createAndSaveFeedback(SpeechBoardEntity speechBoardEntity) {
+        SpeechBoardFeedbackRequest request = SpeechBoardFeedbackRequest.builder()
                 .record(speechBoardEntity.getRecord())
                 .atmosphere(speechBoardEntity.getAtmosphere())
                 .audience(speechBoardEntity.getAudience())
@@ -43,26 +69,30 @@ public class SpeechBoardFeedbackServiceImpl implements SpeechBoardFeedbackServic
                 .deadline(speechBoardEntity.getDeadline())
                 .build();
 
-        SpeechBoardFeedbackResponse speechBoardFeedbackResponse = flaskRequestUtils.requestSpeechBoardFeedback(speechBoardFeedbackRequest);
+        SpeechBoardFeedbackResponse response = flaskRequestUtils.requestSpeechBoardFeedback(request);
 
-        SpeechBoardFeedbackEntity speechBoardFeedbackEntity = SpeechBoardFeedbackEntity.builder()
+        SpeechBoardFeedbackEntity feedbackEntity = SpeechBoardFeedbackEntity.builder()
                 .speechBoardEntity(speechBoardEntity)
-                .originalStt(speechBoardFeedbackResponse.getOriginalStt())
-                .conclusion(speechBoardFeedbackResponse.getConclusion())
-                .score(speechBoardFeedbackResponse.getScore())
+                .originalStt(response.getOriginalStt())
+                .conclusion(response.getConclusion())
+                .score(response.getScore())
                 .build();
-        speechBoardFeedbackRepository.save(speechBoardFeedbackEntity);
+        speechBoardFeedbackRepository.save(feedbackEntity);
 
-        for (String topic : speechBoardFeedbackResponse.getTopics()) {
-            TopicEntity topicEntity = TopicEntity.builder()
-                    .speechBoardEntity(speechBoardEntity)
-                    .topic(topic)
-                    .build();
-            topicRepository.save(topicEntity);
-        }
+        saveTopics(response.getTopics(), speechBoardEntity);
 
-        return speechBoardFeedbackResponse;
+        return response;
     }
+
+    private void saveTopics(List<String> topics, SpeechBoardEntity speechBoardEntity) {
+        topics.stream()
+                .map(topic -> TopicEntity.builder()
+                        .speechBoardEntity(speechBoardEntity)
+                        .topic(topic)
+                        .build())
+                .forEach(topicRepository::save);
+    }
+
 
     @Override
     public SpeechBoardChangeTextResponse speechBoardChangeText(Long speechBoardId , SpeechBoardChangeTextRequest request){

--- a/src/main/java/com/neodo/neodo_backend/topic/infrastructure/TopicJpaRepository.java
+++ b/src/main/java/com/neodo/neodo_backend/topic/infrastructure/TopicJpaRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface TopicJpaRepository extends JpaRepository<TopicEntity, Long> {
     List<TopicEntity> findBySpeechBoardEntityIn(List<SpeechBoardEntity> speechBoardEntities);
+    List<TopicEntity> findBySpeechBoardEntity(SpeechBoardEntity speechBoardEntity);
 }

--- a/src/main/java/com/neodo/neodo_backend/topic/infrastructure/TopicRepositoryImpl.java
+++ b/src/main/java/com/neodo/neodo_backend/topic/infrastructure/TopicRepositoryImpl.java
@@ -27,6 +27,11 @@ public class TopicRepositoryImpl implements TopicRepository {
     }
 
     @Override
+    public List<TopicEntity> findBySpeechBoardEntity(SpeechBoardEntity speechBoardEntity) {
+        return topicJpaRepository.findBySpeechBoardEntity(speechBoardEntity);
+    }
+
+    @Override
     public List<TopicEntity> findBySpeechBoardEntityIn(List<SpeechBoardEntity> speechBoardEntities) {
         return topicJpaRepository.findBySpeechBoardEntityIn(speechBoardEntities);
     }

--- a/src/main/java/com/neodo/neodo_backend/topic/service/port/TopicRepository.java
+++ b/src/main/java/com/neodo/neodo_backend/topic/service/port/TopicRepository.java
@@ -13,4 +13,6 @@ public interface TopicRepository {
     List<TopicEntity> findBySpeechBoardEntityIn(List<SpeechBoardEntity> speechBoardEntities);
 
     Optional<TopicEntity> findById(Long topicId);
+
+    List<TopicEntity> findBySpeechBoardEntity(SpeechBoardEntity speechBoardEntity);
 }


### PR DESCRIPTION
## 🔎 작업 내용

- getMethod로 수정
- 이미 스피치 총평을 받은 경우 플라스크 서버에서 결과를 받아올 필요 없이 DB에 저장된 결과를 바로 반환하도록 로직을 수정

  <br/>


## ➕ 이슈 링크

- [neodo_backend #36 ]

<br/>
