### PR TITLE
refactor: speechCoachingId도 함께 반환하도록 변경

### DIFF
--- a/src/main/java/com/neodo/neodo_backend/speechCoaching/dto/response/SpeechCoachingTopicResponse.java
+++ b/src/main/java/com/neodo/neodo_backend/speechCoaching/dto/response/SpeechCoachingTopicResponse.java
@@ -1,6 +1,7 @@
 package com.neodo.neodo_backend.speechCoaching.dto.response;
 
 import com.neodo.neodo_backend.speechBoard.infrastructure.entity.SpeechBoardEntity;
+import com.neodo.neodo_backend.speechCoaching.infrastructure.entity.SpeechCoachingEntity;
 import com.neodo.neodo_backend.topic.dto.response.TopicResponse;
 import com.neodo.neodo_backend.topic.infrastructure.entity.TopicEntity;
 import lombok.AllArgsConstructor;
@@ -9,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Getter
@@ -20,13 +22,18 @@ public class SpeechCoachingTopicResponse {
     private String title;
     private List<TopicResponse> topics;
 
-    public static SpeechCoachingTopicResponse from(SpeechBoardEntity speechBoard, List<TopicEntity> topics) {
+    public static SpeechCoachingTopicResponse from(SpeechBoardEntity speechBoard,
+                                                   List<TopicEntity> topics,
+                                                   Map<Long, SpeechCoachingEntity> coachingByTopicId) {
         return SpeechCoachingTopicResponse.builder()
                 .speechBoardId(speechBoard.getId())
                 .title(speechBoard.getTitle())
                 .topics(topics.stream()
-                        .map(TopicResponse::from)
-                        .collect(Collectors.toList()))
+                                .map(topic -> TopicResponse.from(
+                                        topic,
+                                        coachingByTopicId.getOrDefault(topic.getId(), null)))
+                                .collect(Collectors.toList()))
                 .build();
     }
+
 }

--- a/src/main/java/com/neodo/neodo_backend/speechCoaching/infrastructure/SpeechCoachingJpaRepository.java
+++ b/src/main/java/com/neodo/neodo_backend/speechCoaching/infrastructure/SpeechCoachingJpaRepository.java
@@ -1,10 +1,13 @@
 package com.neodo.neodo_backend.speechCoaching.infrastructure;
 
 import com.neodo.neodo_backend.speechCoaching.infrastructure.entity.SpeechCoachingEntity;
+import com.neodo.neodo_backend.topic.infrastructure.entity.TopicEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SpeechCoachingJpaRepository extends JpaRepository<SpeechCoachingEntity, Long> {
     Optional<SpeechCoachingEntity> findById(Long speechCoachingId);
+    List<SpeechCoachingEntity> findByTopicEntityIn(List<TopicEntity> topicEntities);
 }

--- a/src/main/java/com/neodo/neodo_backend/speechCoaching/infrastructure/SpeechCoachingRepositoryImpl.java
+++ b/src/main/java/com/neodo/neodo_backend/speechCoaching/infrastructure/SpeechCoachingRepositoryImpl.java
@@ -2,9 +2,11 @@ package com.neodo.neodo_backend.speechCoaching.infrastructure;
 
 import com.neodo.neodo_backend.speechCoaching.infrastructure.entity.SpeechCoachingEntity;
 import com.neodo.neodo_backend.speechCoaching.service.port.SpeechCoachingRepository;
+import com.neodo.neodo_backend.topic.infrastructure.entity.TopicEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -21,5 +23,10 @@ public class SpeechCoachingRepositoryImpl implements SpeechCoachingRepository {
     @Override
     public Optional<SpeechCoachingEntity> findById(Long speechCoachingId) {
         return speechCoachingJpaRepository.findById(speechCoachingId);
+    }
+
+    @Override
+    public List<SpeechCoachingEntity> findByTopicEntityIn(List<TopicEntity> topicEntities) {
+        return speechCoachingJpaRepository.findByTopicEntityIn(topicEntities);
     }
 }

--- a/src/main/java/com/neodo/neodo_backend/speechCoaching/service/SpeechCoachingServiceImpl.java
+++ b/src/main/java/com/neodo/neodo_backend/speechCoaching/service/SpeechCoachingServiceImpl.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.neodo.neodo_backend.external.aws.config.S3Config.S3_BUCKET_URL;
@@ -88,15 +89,21 @@ public class SpeechCoachingServiceImpl implements SpeechCoachingService {
     public List<SpeechCoachingTopicResponse> get(UserEntity user) {
         List<SpeechBoardEntity> speechBoardEntities = speechBoardRepository.findByUserId(user.getId());
         List<TopicEntity> topicEntities = topicRepository.findBySpeechBoardEntityIn(speechBoardEntities);
+        List<SpeechCoachingEntity> speechCoachingEntities = speechCoachingRepository.findByTopicEntityIn(topicEntities);
 
-        Map<Long, List<TopicEntity>> topicsByBoardId = topicEntities.stream()
+        Map<Long, SpeechCoachingEntity> speechCoachingEntityByTopicId = speechCoachingEntities.stream()
+                .collect(Collectors.toMap(
+                        speechCoachingEntity -> speechCoachingEntity.getTopicEntity().getId(),
+                        Function.identity()));
+
+        Map<Long, List<TopicEntity>> topicsBySpeechBoardId = topicEntities.stream()
                 .collect(Collectors.groupingBy(topic -> topic.getSpeechBoardEntity().getId()));
 
         return speechBoardEntities.stream()
-                .map(speechBoard -> SpeechCoachingTopicResponse.from(
-                        speechBoard,
-                        topicsByBoardId.getOrDefault(speechBoard.getId(), Collections.emptyList()) // 해당 보드에 토픽이 없으면 빈 리스트 반환
-                ))
+                .map(speechBoardEntity -> SpeechCoachingTopicResponse.from(
+                        speechBoardEntity,
+                        topicsBySpeechBoardId.getOrDefault(speechBoardEntity.getId(), Collections.emptyList()),
+                        speechCoachingEntityByTopicId))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/neodo/neodo_backend/speechCoaching/service/port/SpeechCoachingRepository.java
+++ b/src/main/java/com/neodo/neodo_backend/speechCoaching/service/port/SpeechCoachingRepository.java
@@ -1,10 +1,13 @@
 package com.neodo.neodo_backend.speechCoaching.service.port;
 
 import com.neodo.neodo_backend.speechCoaching.infrastructure.entity.SpeechCoachingEntity;
+import com.neodo.neodo_backend.topic.infrastructure.entity.TopicEntity;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SpeechCoachingRepository {
     SpeechCoachingEntity save(SpeechCoachingEntity speechCoachingEntity);
     Optional<SpeechCoachingEntity> findById(Long speechCoachingId);
+    List<SpeechCoachingEntity> findByTopicEntityIn(List<TopicEntity> topicEntities);
 }

--- a/src/main/java/com/neodo/neodo_backend/topic/dto/response/TopicResponse.java
+++ b/src/main/java/com/neodo/neodo_backend/topic/dto/response/TopicResponse.java
@@ -1,19 +1,26 @@
 package com.neodo.neodo_backend.topic.dto.response;
 
+import com.neodo.neodo_backend.speechCoaching.infrastructure.entity.SpeechCoachingEntity;
 import com.neodo.neodo_backend.topic.infrastructure.entity.TopicEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Optional;
+
 @Getter
 @AllArgsConstructor
 @Builder
 public class TopicResponse {
+    private Long speechCoachingId;
     private Long topicId;
     private String topic;
 
-    public static TopicResponse from(TopicEntity topicEntity) {
+    public static TopicResponse from(TopicEntity topicEntity, SpeechCoachingEntity speechCoachingEntity) {
         return TopicResponse.builder()
+                .speechCoachingId(
+                        Optional.ofNullable(speechCoachingEntity)
+                                .map(SpeechCoachingEntity::getId).orElse(null))
                 .topicId(topicEntity.getId())
                 .topic(topicEntity.getTopic())
                 .build();


### PR DESCRIPTION
## 🔎 작업 내용

- speechCoachingId도 함께 반환하도록 변경

  <br/>

## 이미지 첨부
<img width="531" alt="스크린샷 2025-03-16 오후 11 59 11" src="https://github.com/user-attachments/assets/4f81208b-cbb7-4cfd-bc77-53e912c35841" />

녹음파일 업로드를 했다면 speechCoachingId가 존재, 
하지 않았다면 speechCoachingId이 null값으로 반환

<br/>

## ➕ 이슈 링크

- [neodo_backend #38 ]

<br/>
